### PR TITLE
Don't edit local versions of systemd files.

### DIFF
--- a/restic_install.sh
+++ b/restic_install.sh
@@ -39,9 +39,9 @@ for job in $running_jobs; do
 done
 
 # copy over systemd files
-sed -i "s/_USER_/$(logname)/" ./systemd/*.service
-cp ./systemd/* /etc/systemd/system/
-
+for file in ./systemd/*; do
+    sed "s/_USER_/$(logname)/" "$file" > /etc/systemd/system/"${file##*/}"
+done
 
 for config_file in *.env; do
     # copy all env files


### PR DESCRIPTION
The current command edits the systemd files inline and then copies them
over.  The problem with this is it leaves the files in an edited state
and they could easily be checked in with other changes.

Instead, edit the files and then write them directly to their
destination instead of saving back to the original file first.