### PR TITLE
Add more fine-grained control over the removal of snapshots

### DIFF
--- a/call_restic
+++ b/call_restic
@@ -20,7 +20,12 @@ if [[ $2 =~ [Bb]ackup ]]; then
 fi
 
 if [[ $2 =~ [Cc]lean ]]; then
-	restic forget --prune -l "$SNAPSHOTS_TO_REMEMBER"
+	restic forget --prune \
+	${RESTIC_KEEP_HOURLY:+--keep-hourly ${RESTIC_KEEP_HOURLY}} \
+	${RESTIC_KEEP_DAILY:+--keep-daily ${RESTIC_KEEP_DAILY}} \
+	${RESTIC_KEEP_WEEKLY:+--keep-weekly ${RESTIC_KEEP_WEEKLY}} \
+	${RESTIC_KEEP_MONTHLY:+--keep-monthly ${RESTIC_KEEP_MONTHLY}} \
+	${RESTIC_KEEP_YEARLY:+--keep-yearly ${RESTIC_KEEP_YEARLY}}
 fi
 
 if [[ $2 =~ [Uu]nlock ]]; then

--- a/config.env.template
+++ b/config.env.template
@@ -1,7 +1,11 @@
 export RESTIC_REPOSITORY=       # Example: s3:http://<ipaddr>:9000/restic-agelter-test
 export RESTIC_PASSWORD=         # Example: myPassword
-export SNAPSHOTS_TO_REMEMBER=3
 export PATH_TO_BACKUP=          # Example: /backup/file
 export AWS_SECRET_ACCESS_KEY=   # Example foo/bar
 export AWS_ACCESS_KEY_ID=       # Example: blehKeyId 
 export MAX_UPLOAD_RATE=         # Example: 100 (Kbps)
+export RESTIC_KEEP_HOURLY=      # Number of hourly snapshots to keep (keep empty to ignore)
+export RESTIC_KEEP_DAILY=       # Number of daily snapshots to keep (keep empty to ignore)
+export RESTIC_KEEP_WEEKLY=      # Number of weekly snapshots to keep (keep empty to ignore)
+export RESTIC_KEEP_MONTHLY=     # Number of monthly snapshots to keep (keep empty to ignore)
+export RESTIC_KEEP_YEARLY=      # Number of yearly snapshots to keep (keep empty to ignore)


### PR DESCRIPTION
Instead of simply deleting the last x snapshots, we add the ability to
specify the number of hourly, daily, weekly, monthly, and yearly
snapshots to keep.

Signed-off-by: Aaron Gelter <aaron@gelter.com>